### PR TITLE
Fix some failing unit tests locally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :test do
   gem "timecop", "~> 0.9.1"
   gem "rspec_junit_formatter"
   gem "rack-test"
+  gem 'webdrivers', "~> 4.4"
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1262,6 +1262,10 @@ GEM
       activemodel (>= 4.2)
       debug_inspector
       railties (>= 4.2)
+    webdrivers (4.4.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -1322,6 +1326,7 @@ DEPENDENCIES
   timecop (~> 0.9.1)
   vcr (~> 3.0.3)
   web-console (>= 3.3.0)
+  webdrivers (~> 4.4)
   webmock (~> 3.8.0)
   webpacker (~> 5.2)
   yajl-ruby (~> 1.3.1)


### PR DESCRIPTION
## Description

Some unit tests might fail with the following error:

Selenium::WebDriver::Error::WebDriverError:
  unable to connect to chromedriver 127.0.0.1:9515

Adding this gem will fix the issue.

## Note
You might also need to do `brew install chromium-chromedriver` if on MacOS.