### PR TITLE
Adds dynamic service heading

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,8 +4,7 @@ module ApplicationHelper
   end
 
   def service_choice
-    @service_choice ||=
-      TradeTariffFrontend::ServiceChooser.service_choice ||
+    TradeTariffFrontend::ServiceChooser.service_choice ||
       TradeTariffFrontend::ServiceChooser::SERVICE_DEFAULT
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,12 @@
 module ApplicationHelper
+  def trade_tariff_heading
+    service_choice =
+      TradeTariffFrontend::ServiceChooser.service_choice ||
+      TradeTariffFrontend::ServiceChooser::SERVICE_DEFAULT
+
+    t('trade_tariff_heading')[service_choice.to_sym]
+  end
+
   def govspeak(text)
     text = text['content'] || text[:content] if text.is_a?(Hash)
     return '' if text.nil?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,12 @@
 module ApplicationHelper
   def trade_tariff_heading
-    service_choice =
+    t('trade_tariff_heading')[service_choice.to_sym]
+  end
+
+  def service_choice
+    @service_choice ||=
       TradeTariffFrontend::ServiceChooser.service_choice ||
       TradeTariffFrontend::ServiceChooser::SERVICE_DEFAULT
-
-    t('trade_tariff_heading')[service_choice.to_sym]
   end
 
   def govspeak(text)

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -19,7 +19,7 @@
 <% content_for :proposition_header do %>
   <div class="govuk-header__content">
     <a href="<%= sections_path %>" class="govuk-header__link govuk-header__link--service-name" id="proposition-name">
-      Trade Tariff
+      <%= trade_tariff_heading %>
     </a>
     <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="proposition-links" aria-label="Show or hide Top Level Navigation">Menu</button>
     <nav id="proposition-menu"  aria-label="Top Level Navigation">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,3 +7,7 @@ en:
   geographical_areas:
     descriptions:
       erga_omnes: "All countries"
+  trade_tariff_heading:
+    uk-old: "The Online Trade Tariff"
+    uk: "The Online Trade Tariff"
+    xi: "The Northern Ireland (EU) Tariff for the XI"

--- a/spec/features/service_choices_spec.rb
+++ b/spec/features/service_choices_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'Service choices', js: true do
+  # TODO: Make the service choice using the change service choice link when implemented
+  around do |example|
+    TradeTariffFrontend::ServiceChooser.service_choice = choice
+    example.call
+    TradeTariffFrontend::ServiceChooser.service_choice = nil
+  end
+
+  let(:capybara_host) { Capybara.current_session.server.base_url }
+
+  context 'when using the default service as the current service backend' do
+    let(:choice) { nil }
+
+    it 'displays the correct tariff heading' do
+      VCR.use_cassette('sections#index', record: :new_episodes) do
+        visit sections_path
+
+        expect(page).to have_link('The Online Trade Tariff', href: '/sections')
+      end
+    end
+  end
+
+  context 'when using uk as the current service backend' do
+    let(:choice) { 'uk' }
+
+    it 'displays the correct tariff heading' do
+      VCR.use_cassette('sections#index', record: :new_episodes) do
+        visit sections_path
+
+        expect(page).to have_link('The Online Trade Tariff', href: '/uk/sections')
+      end
+    end
+  end
+
+  # TODO: Remove me when old uk service is removed
+  context 'when using uk-old as the current service backend' do
+    let(:choice) { 'uk-old' }
+
+    it 'displays the correct tariff heading' do
+      VCR.use_cassette('sections#index', record: :new_episodes) do
+        visit sections_path
+
+        expect(page).to have_link('The Online Trade Tariff', href: '/sections')
+      end
+    end
+  end
+
+  context 'when using xi as the current service backend' do
+    let(:choice) { 'xi' }
+
+    it 'displays the correct tariff heading' do
+      VCR.use_cassette('sections#index', record: :new_episodes) do
+        visit sections_path
+
+        expect(page).to have_link('The Northern Ireland (EU) Tariff for the XI', href: '/xi/sections')
+      end
+    end
+  end
+end


### PR DESCRIPTION
jira link: https://transformuk.atlassian.net/browse/HOTT-82

Adds a new heading for uk and xi services and consume them in the
basey layout

Add feature spec to show the heading behaviour when:

1. In default mode
2. In uk mode
3. In uk-old mode
4. In xi mode

![Screenshot from 2020-12-14 17-21-12](https://user-images.githubusercontent.com/8156884/102115876-0d762480-3e34-11eb-85df-4eb4d8375fd9.png)
![Screenshot from 2020-12-14 17-21-24](https://user-images.githubusercontent.com/8156884/102115878-0d762480-3e34-11eb-835e-a3d97d6ca765.png)
![Screenshot from 2020-12-14 17-21-51](https://user-images.githubusercontent.com/8156884/102115879-0e0ebb00-3e34-11eb-87d4-3b317279d65a.png)
![Screenshot from 2020-12-14 17-42-58](https://user-images.githubusercontent.com/8156884/102115881-0e0ebb00-3e34-11eb-8ef5-6a34afe70fef.png)
