### PR TITLE
HOTFIX - Handle service choice prefix in version header and path

### DIFF
--- a/lib/trade_tariff_frontend/request_forwarder.rb
+++ b/lib/trade_tariff_frontend/request_forwarder.rb
@@ -17,6 +17,8 @@ module TradeTariffFrontend
       case rackreq.request_method
       # The API is read-only
       when "GET", "HEAD"
+        remove_service_choice_prefix!(rackreq)
+
         api_version = rackreq.path
                              .downcase
                              .split('/')
@@ -27,6 +29,7 @@ module TradeTariffFrontend
           rackreq.request_method.downcase,
           request_url_for(rackreq)
         ) do |req|
+
           req.headers['Accept'] = "application/vnd.uktt.#{api_version}"
           req.headers['Content-Type'] = env['CONTENT_TYPE']
           req.options.timeout = 60           # open/read timeout in seconds
@@ -86,6 +89,13 @@ module TradeTariffFrontend
       cache_control = ["max-age=#{is_error ? 0 : 3600}"]
       cache_control.unshift('no-store') if is_error
       cache_control.join(', ')
+    end
+
+    def remove_service_choice_prefix!(rackreq)
+      choice = TradeTariffFrontend::ServiceChooser.service_choice
+      prefix = "/#{choice}"
+
+      rackreq.path_info = rackreq.path_info.sub(prefix, '') if choice.present?
     end
   end
 end


### PR DESCRIPTION
The `RequestForwarder` class uses the original path that was constructed
before adjustments around service choices were made in the path prefix.

This reversion to the original path is done to make sure the logs indicate the original path
that was used for the current request and because the custom
`RequestForwarder` falls out of the `ActionDispatch::Journey::Router` process around recognising a route.

The backend does not expect the prefix to be in the path or the version
so we have to remove it.

I'm leaving the `Accept` header version behaviour as is (despite it being broken) and
will sort this out later down the line.

For posterity, I believe it's behaviour should be:

1. Accept is application/vnd.uktt.v1 if /v1 is the prefix
2. Accept is application/vnd.uktt.v2 if /v2 is the prefix
3. Accept is application/vnd.uktt.v2 if the path has no version prefix