### PR TITLE
Fixes VCR failing specs that involve a request to pull chromedriver

### DIFF
--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -9,7 +9,11 @@ VCR.configure do |c|
   c.default_cassette_options = { match_requests_on: [:path] }
   c.configure_rspec_metadata!
   c.ignore_request do |request|
-    URI(request.uri).host.in?(%w(localhost 127.0.0.1)) &&
-      service_ports.exclude?(URI(request.uri).port)
+    if request.uri.start_with?("https://chromedriver.storage.googleapis.com")
+      true
+    else
+      URI(request.uri).host.in?(%w(localhost 127.0.0.1)) &&
+        service_ports.exclude?(URI(request.uri).port)
+    end
   end
 end


### PR DESCRIPTION
When you execute vcr specs without chromedriver installed you'll get
test failures that show that you're missing stubbing a request to
download the latest chromedriver.

This is intermittent because some of the tests execute out of a vcr
scope and download the webdriver.

If non-vcr tests run first we have no issue (webdriver downloaded)
If vcr tests run first we have an external call to download the driver
and propagate a failure for the test