### PR TITLE
Add link to switch between the services

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,13 +1,4 @@
 module ApplicationHelper
-  def trade_tariff_heading
-    t('trade_tariff_heading')[service_choice.to_sym]
-  end
-
-  def service_choice
-    TradeTariffFrontend::ServiceChooser.service_choice ||
-      TradeTariffFrontend::ServiceChooser::SERVICE_DEFAULT
-  end
-
   def govspeak(text)
     text = text['content'] || text[:content] if text.is_a?(Hash)
     return '' if text.nil?

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,0 +1,24 @@
+module ServiceHelper
+  def trade_tariff_heading
+    t('trade_tariff_heading')[service_choice.to_sym]
+  end
+
+  # TODO: Remove the uk-old case when we switch to the new UK version
+  def switch_service_link
+    current_path = request.filtered_path.sub("/#{service_choice}", '')
+
+    case service_choice
+    when 'uk-old' then link_to(t('trade_tariff_heading')[:xi], "/xi#{current_path}")
+    when 'uk' then link_to(t('trade_tariff_heading')[:xi], "/xi#{current_path}")
+    else
+      link_to(t('trade_tariff_heading')['uk-old'.to_sym], current_path)
+    end
+  end
+
+  private
+
+  def service_choice
+    TradeTariffFrontend::ServiceChooser.service_choice ||
+      TradeTariffFrontend::ServiceChooser::SERVICE_DEFAULT
+  end
+end

--- a/app/views/chapters/_chapter_guides.html.erb
+++ b/app/views/chapters/_chapter_guides.html.erb
@@ -1,13 +1,3 @@
 <% if chapter.guides &&
-      !chapter.guides.empty? %>
-<div class="chapter-guide govuk-!-margin-top-4">
-  Get guidance on this product area:
-  <% chapter.guides.each do |guide| %>
-    <% separator = chapter.guides.index(guide) < (chapter.guides.length - 1) ? ",&nbsp;".html_safe : "" %>
-    <a href="<%= guide['url'] %>" class="chapter-guide-link" data-analytics-event="guidance"><%= guide['title'] %></a><%= separator %>
-  <% end %>
-  <% if chapter && chapter.short_code %>
-    or <a href="<%= chapter_forum_url(chapter) %>" data-analytics-event="forums" title="Discuss chapter <%= chapter.short_code %> in the forums">Discuss this chapter in the forums</a>
-  <% end %>
-</div>
+  !chapter.guides.empty? %>
 <% end %>

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -48,9 +48,6 @@
         <%= govuk_header_navigation_item(exchange_rates_active_class) do %>
           <%= link_to "Exchange rates", exchange_rates_path, class: "govuk-header__link" %>
         <% end %>
-        <%= govuk_header_navigation_item do %>
-          <%= link_to "Forum", "https://forum.trade-tariff.service.gov.uk/", target: "_blank", class: "govuk-header__link", data: { analytics_event: "forums" } %>
-        <% end %>
       </ul>
     </nav>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,6 +69,12 @@
 
     <main id="content" class="govuk-main-wrapper" role="main">
       <%= render 'shared/search' %>
+      <div class="tariff-breadcrumbs js-tariff-breadcrumbs clt govuk-!-font-size-15 govuk-!-margin-bottom-7">
+        <nav>
+          <p>Switch to the <%= switch_service_link %></a>.</p>
+        </nav>
+      </div>
+
       <%= yield %>
       <% if @tariff_last_updated %>
         <div id="last-updated-at"><p class="govuk-!-font-size-16">Last updated: <%= @tariff_last_updated.strftime("%e %B %Y") %>&emsp;<a href="https://www.gov.uk/government/collections/tariff-stop-press-notices" target="_blank">View latest amendments</a></p></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,4 +10,4 @@ en:
   trade_tariff_heading:
     uk-old: "The Online Trade Tariff"
     uk: "The Online Trade Tariff"
-    xi: "The Northern Ireland (EU) Tariff for the XI"
+    xi: "The Northern Ireland (EU) Tariff"

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe ServiceHelper, type: :helper do
+  before do
+    allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return(choice)
+  end
+
+  describe ".trade_tariff_heading" do
+    context 'when the selected service choice is uk-old' do
+      let(:choice) { 'uk-old' }
+
+      it 'returns The Online Trade Tariff' do
+        expect(trade_tariff_heading).to eq('The Online Trade Tariff')
+      end
+    end
+
+    context 'when the selected service choice is uk' do
+      let(:choice) { 'uk' }
+
+      it 'returns The Online Trade Tariff' do
+        expect(trade_tariff_heading).to eq('The Online Trade Tariff')
+      end
+    end
+
+    context 'when the selected service choice is xi' do
+      let(:choice) { 'xi' }
+
+      it 'returns The Northern Ireland (EU) Tariff for the XI' do
+        expect(trade_tariff_heading).to eq('The Northern Ireland (EU) Tariff for the XI')
+      end
+    end
+  end
+
+  describe ".switch_service_link" do
+    let(:request) { double('request', filtered_path: path) }
+
+    before do
+      allow(helper).to receive(:request).and_return(request)
+    end
+
+    context 'when the selected service choice is uk-old' do
+      let(:path) { '/sections/1' }
+      let(:choice) { 'uk-old' }
+
+      it 'returns the link to the XI service' do
+        expect(switch_service_link).to eq(link_to('The Northern Ireland (EU) Tariff for the XI', '/xi/sections/1'))
+      end
+    end
+
+    context 'when the selected service choice is uk' do
+      let(:path) { '/uk/sections/1' }
+      let(:choice) { 'uk' }
+
+      it 'returns the link to the XI service' do
+        expect(switch_service_link).to eq(link_to('The Northern Ireland (EU) Tariff for the XI', '/xi/sections/1'))
+      end
+    end
+
+    context 'when the selected service choice is xi' do
+      let(:path) { '/xi/sections/1' }
+      let(:choice) { 'xi' }
+
+      it 'returns the link to the current UK service' do
+        expect(switch_service_link).to eq(link_to('The Online Trade Tariff', '/sections/1'))
+      end
+    end
+  end
+end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -25,8 +25,8 @@ describe ServiceHelper, type: :helper do
     context 'when the selected service choice is xi' do
       let(:choice) { 'xi' }
 
-      it 'returns The Northern Ireland (EU) Tariff for the XI' do
-        expect(trade_tariff_heading).to eq('The Northern Ireland (EU) Tariff for the XI')
+      it 'returns The Northern Ireland (EU) Tariff' do
+        expect(trade_tariff_heading).to eq('The Northern Ireland (EU) Tariff')
       end
     end
   end
@@ -43,7 +43,7 @@ describe ServiceHelper, type: :helper do
       let(:choice) { 'uk-old' }
 
       it 'returns the link to the XI service' do
-        expect(switch_service_link).to eq(link_to('The Northern Ireland (EU) Tariff for the XI', '/xi/sections/1'))
+        expect(switch_service_link).to eq(link_to('The Northern Ireland (EU) Tariff', '/xi/sections/1'))
       end
     end
 
@@ -52,7 +52,7 @@ describe ServiceHelper, type: :helper do
       let(:choice) { 'uk' }
 
       it 'returns the link to the XI service' do
-        expect(switch_service_link).to eq(link_to('The Northern Ireland (EU) Tariff for the XI', '/xi/sections/1'))
+        expect(switch_service_link).to eq(link_to('The Northern Ireland (EU) Tariff', '/xi/sections/1'))
       end
     end
 


### PR DESCRIPTION
# Context

- Add a link that enables users to switch between the UK
and XI services anywhere in the service.
- remove the link to the Forum
- remove the link to the goods classification

# Ticket
https://transformuk.atlassian.net/browse/HOTT-96