### PR TITLE
Adds missing unit tests for ServiceChooser

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,3 +38,5 @@ RSpec/DescribeClass:
     - tasks/**/*.rb
 RSpec/ExampleLength:
   Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: single_quotes

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -100,8 +100,6 @@ module TradeTariffFrontend
       host
     end
 
-    private
-
     def cache_prefix
       service_choice || SERVICE_DEFAULT
     end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -92,16 +92,18 @@ module TradeTariffFrontend
       end
     end
 
-    def cache_prefix
-      service_choice || SERVICE_DEFAULT
-    end
-
     def api_host
       host = service_choices[service_choice]
 
       return service_choices[SERVICE_DEFAULT] if host.blank?
 
       host
+    end
+
+    private
+
+    def cache_prefix
+      service_choice || SERVICE_DEFAULT
     end
   end
   

--- a/spec/trade_tariff_frontend/service_chooser_spec.rb
+++ b/spec/trade_tariff_frontend/service_chooser_spec.rb
@@ -1,9 +1,55 @@
 require 'spec_helper'
 
 describe TradeTariffFrontend::ServiceChooser do
+  describe '.service_choices' do
+    it 'returns a Hash of url options for the services' do
+      expect(described_class.service_choices).to eq(
+        "uk" => "http://localhost:3018",
+        "uk-old" => "http://localhost:3018",
+        "xi" => "http://localhost:3019"
+      )
+    end
+  end
+
+  describe '.service_choice=' do
+    it 'assigns the service choice to the current Thread' do
+      expect { described_class.service_choice = 'xi' }
+        .to change { Thread.current[:service_choice] }
+        .from(nil)
+        .to('xi')
+
+      # Don't pollute other tests with the service choice value
+      described_class.service_choice = nil
+    end
+  end
+
+  describe '.api_host' do
+    around do |example|
+      Thread.current[:service_choice] = choice
+      example.run
+      Thread.current[:service_choice] = nil
+    end
+
+    context 'when the service choice does not have a corresponding url' do
+      let(:choice) { 'foo' }
+
+      it 'returns the default service choice url' do
+        expect(described_class.api_host).to eq('http://localhost:3018')
+      end
+    end
+
+    context 'when the service choice has a corresponding url' do
+      let(:choice) { 'xi' }
+
+      it 'returns the service choice url' do
+        expect(described_class.api_host).to eq('http://localhost:3019')
+      end
+    end
+  end
+
   describe '.cache_with_service_choice' do
-    let(:cache_key) { 'foo' } 
-    let(:options) { {} } 
+    let(:cache_key) { 'foo' }
+    let(:options) { {} }
 
     before do
       described_class.service_choice = choice

--- a/spec/trade_tariff_frontend/service_chooser_spec.rb
+++ b/spec/trade_tariff_frontend/service_chooser_spec.rb
@@ -1,12 +1,16 @@
 require 'spec_helper'
 
 describe TradeTariffFrontend::ServiceChooser do
+  after do
+    Thread.current[:service_choice] = nil
+  end
+
   describe '.service_choices' do
     it 'returns a Hash of url options for the services' do
       expect(described_class.service_choices).to eq(
-        "uk" => "http://localhost:3018",
-        "uk-old" => "http://localhost:3018",
-        "xi" => "http://localhost:3019"
+        'uk' => 'http://localhost:3018',
+        'uk-old' => 'http://localhost:3018',
+        'xi' => 'http://localhost:3019',
       )
     end
   end
@@ -17,17 +21,12 @@ describe TradeTariffFrontend::ServiceChooser do
         .to change { Thread.current[:service_choice] }
         .from(nil)
         .to('xi')
-
-      # Don't pollute other tests with the service choice value
-      described_class.service_choice = nil
     end
   end
 
   describe '.api_host' do
-    around do |example|
+    before do
       Thread.current[:service_choice] = choice
-      example.run
-      Thread.current[:service_choice] = nil
     end
 
     context 'when the service choice does not have a corresponding url' do
@@ -54,10 +53,6 @@ describe TradeTariffFrontend::ServiceChooser do
     before do
       described_class.service_choice = choice
       allow(Rails.cache).to receive(:fetch)
-    end
-
-    after do
-      described_class.service_choice = nil
     end
 
     context 'when the service choice is nil' do


### PR DESCRIPTION
**What**

Adds missing unit specs for the ServiceChooser module

**Why**

This coverage was missing before (apart from at the integration level).