### PR TITLE
Removes RSS aesthetic functionality

### DIFF
--- a/app/helpers/commodities_helper.rb
+++ b/app/helpers/commodities_helper.rb
@@ -117,10 +117,7 @@ module CommoditiesHelper
         content_tag(:div, format_commodity_code(commodity), class: 'code-text')
       end
       tree_commodity_code(commodity) +
-      content_tag(:p, commodity.to_s.html_safe) +
-      content_tag(:div, class: 'feed') do
-        link_to('Changes', commodity_changes_path(commodity.declarable, format: :atom), rel: "nofollow")
-      end
+      content_tag(:p, commodity.to_s.html_safe)
     end
   end
 
@@ -132,10 +129,7 @@ module CommoditiesHelper
                   'aria-describedby' => "commodity-#{commodity.code}") do
         content_tag(:div, format_full_code(commodity), class: 'code-text')
       end
-      content_tag(:p, commodity.to_s.html_safe) +
-        content_tag(:div, class: 'feed') do
-          link_to('Changes', commodity_changes_path(commodity.declarable, format: :atom), rel: "nofollow")
-        end
+      content_tag(:p, commodity.to_s.html_safe)
     end
   end
 

--- a/app/views/shared/_tariff_breadcrumbs.html.erb
+++ b/app/views/shared/_tariff_breadcrumbs.html.erb
@@ -80,7 +80,6 @@ declarable ||= false %>
             </ul>
           </li>
         </ul>
-        <div class="feed"><%= link_to 'Changes', heading_changes_path(@heading.declarable, format: :atom), rel: "nofollow" %></div>
       </div>
       <div class="mobile-only">
         <ul class="js-full-tree">
@@ -91,7 +90,6 @@ declarable ||= false %>
               <li class="heading-li">
                 <%= tree_heading_code(heading) %>
                 <p><%= heading.formatted_description.html_safe %></p>
-                <div class="feed"><%= link_to 'Changes', heading_changes_path(@heading.declarable, format: :atom), rel: "nofollow" %></div>
               </li>
             </ul>
           </li>
@@ -103,7 +101,6 @@ declarable ||= false %>
               <li class="chapter-and-heading-li">
                 <%= tree_heading_code(heading) %>
                 <p><%= heading.formatted_description.html_safe %></p>
-                <div class="feed"><%= link_to 'Changes', heading_changes_path(@heading.declarable, format: :atom), rel: "nofollow" %></div>
               </li>
             </ul>
           </li>
@@ -121,7 +118,6 @@ declarable ||= false %>
             <%= chapter %>
           </p>
 
-          <div class="feed"><%= link_to 'Changes', chapter_changes_path(@chapter, format: :atom), rel: 'nofollow' %></div>
           <% if TradeTariffFrontend.download_pdf_enabled? %>
             <div class="download-pdf"><%= link_to 'Download PDF', download_chapter_pdf_url(chapter.section.position, chapter.short_code), rel: 'nofollow', target: '_blank' %></div>
           <% end %>


### PR DESCRIPTION
**What**

Jira link: https://transformuk.atlassian.net/browse/HOTT-139

Removes only the aesthetic layer of RSS functionality from the frontend.

**Why**

This is no longer required.