### PR TITLE
Update dynamic page title

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ inherit_gem:
 require: rubocop-rspec
 
 AllCops:
+  TargetRubyVersion: 2.7.1
   Exclude:
     - 'db/schema.rb'
     - 'vendor/**/*'

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,15 +1,36 @@
 module ServiceHelper
+  def default_title
+    t("title.default", service_name: service_name, service_description: service_description)
+  end
+
+  def goods_nomenclature_title(goods_nomenclature)
+    t(
+      "title.goods_nomenclature",
+      goods_description: goods_nomenclature.to_s,
+      service_name: service_name,
+    )
+  end
+
+  def commodity_title(commodity)
+    t(
+      "title.commodity.#{service_choice}",
+      commodity_description: commodity.to_s,
+      commodity_code: commodity.code,
+      service_name: service_name,
+    )
+  end
+
   def trade_tariff_heading
-    t("trade_tariff_heading")[service_choice.to_sym]
+    t("trade_tariff_heading.#{service_choice}")
   end
 
   # TODO: Remove the uk-old case when we switch to the new UK version
   def switch_service_link
     case service_choice
-    when "uk-old" then link_to(t("trade_tariff_heading")[:xi], "/xi#{current_path}")
-    when "uk" then link_to(t("trade_tariff_heading")[:xi], "/xi#{current_path}")
+    when "uk-old" then link_to(t("trade_tariff_heading.xi"), "/xi#{current_path}")
+    when "uk" then link_to(t("trade_tariff_heading.xi"), "/xi#{current_path}")
     else
-      link_to(t("trade_tariff_heading")["uk-old".to_sym], current_path)
+      link_to(t("trade_tariff_heading.uk-old"))
     end
   end
 
@@ -24,6 +45,14 @@ module ServiceHelper
   end
 
 private
+
+  def service_name
+    t("title.service_name.#{service_choice}")
+  end
+
+  def service_description
+    t("title.service_description")
+  end
 
   def service_choice
     TradeTariffFrontend::ServiceChooser.service_choice ||

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -30,7 +30,7 @@ module ServiceHelper
     when "uk-old" then link_to(t("trade_tariff_heading.xi"), "/xi#{current_path}")
     when "uk" then link_to(t("trade_tariff_heading.xi"), "/xi#{current_path}")
     else
-      link_to(t("trade_tariff_heading.uk-old"))
+      link_to(t("trade_tariff_heading.uk-old"), current_path)
     end
   end
 

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -51,7 +51,7 @@ private
   end
 
   def service_description
-    t("title.service_description")
+    t('title.service_description')
   end
 
   def service_choice

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{@chapter} - Trade Tariff - GOV.UK" %>
+<% content_for :title, goods_nomenclature_title(@chapter) %>
 <% content_for :head do %>
   <meta name="description" content="<%= @chapter  %>">
   <link rel='alternate' type='application/json' href='<%= chapter_url(@chapter, format: :json) %>' title='Chapter information page in JSON format' />

--- a/app/views/declarables/_declarable.html.erb
+++ b/app/views/declarables/_declarable.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Commodity code - #{declarable.code} - #{declarable.description_plain} - Trade Tariff - GOV.UK" %>
+<% content_for :title, commodity_title(declarable) %>
 
 <article class="tariff commodity">
   <%= render 'shared/tariff_breadcrumbs', declarable: declarable %>

--- a/app/views/headings/show.html.erb
+++ b/app/views/headings/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{@heading} - Trade Tariff - GOV.UK" %>
+<% content_for :title, goods_nomenclature_title(@heading) %>
 <% content_for :head do %>
   <meta name="description" content="<%= @heading %>">
   <link rel='alternate' type='application/json' href='<%= heading_url(@heading, format: :json) %>' title='Heading information page in JSON format' />

--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -1,4 +1,4 @@
-<% content_for :pageTitle, content_for?(:title) ? yield(:title) : "Trade Tariff: look up commodity codes, duty and VAT rates - GOV.UK" %>
+<% content_for :pageTitle, content_for?(:title) ? yield(:title) : default_title %>
 
 <% content_for :head do %>
   <%= csrf_meta_tags %>

--- a/app/views/sections/show.html.erb
+++ b/app/views/sections/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{@section} - Trade Tariff - GOV.UK" %>
+<% content_for :title, goods_nomenclature_title(@section) %>
 <% content_for :head do %>
   <meta name="description" content="<%= @section %>">
   <link rel='alternate' type='application/json' href='<%= section_url(@section, format: :json) %>' title='Section information page in JSON format' />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,11 +4,23 @@
 en:
   meta_description: "Search for import and export commodity codes and for tax, duty and licences that apply to your goods"
 
+  title: 
+    default: "%{service_name}: %{service_description} - GOV.UK"
+    goods_nomenclature: "%{goods_description} - %{service_name} - GOV.UK"
+    commodity: 
+      uk-old: "Commodity code %{commodity_code} - %{commodity_description} - %{service_name} - GOV.UK"
+      uk: "Commodity code %{commodity_code}: %{commodity_description} - %{service_name} - GOV.UK"
+      xi: "Commodity code %{commodity_code}: %{commodity_description} - %{service_name} - GOV.UK"
+    service_description: "Look up commodity codes, import duty, VAT and controls - GOV.UK"
+    service_name:
+      uk-old: "Trade Tariff"
+      uk: "The Online Trade Tariff"
+      xi: "The Northern Ireland (EU) Tariff"
   geographical_areas:
     descriptions:
       erga_omnes: "All countries"
   trade_tariff_heading:
-    uk-old: "The Online Trade Tariff"
+    uk-old: "Trade Tariff"
     uk: "The Online Trade Tariff"
     xi: "The Northern Ireland (EU) Tariff"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,19 +8,19 @@ en:
     default: "%{service_name}: %{service_description} - GOV.UK"
     goods_nomenclature: "%{goods_description} - %{service_name} - GOV.UK"
     commodity: 
-      uk-old: "Commodity code %{commodity_code} - %{commodity_description} - %{service_name} - GOV.UK"
+      uk-old: "Commodity code %{commodity_code}: %{commodity_description} - %{service_name} - GOV.UK"
       uk: "Commodity code %{commodity_code}: %{commodity_description} - %{service_name} - GOV.UK"
       xi: "Commodity code %{commodity_code}: %{commodity_description} - %{service_name} - GOV.UK"
     service_description: "Look up commodity codes, import duty, VAT and controls - GOV.UK"
     service_name:
-      uk-old: "Trade Tariff"
+      uk-old: "The Online Trade Tariff"
       uk: "The Online Trade Tariff"
       xi: "The Northern Ireland (EU) Tariff"
   geographical_areas:
     descriptions:
       erga_omnes: "All countries"
   trade_tariff_heading:
-    uk-old: "Trade Tariff"
+    uk-old: "The Online Trade Tariff"
     uk: "The Online Trade Tariff"
     xi: "The Northern Ireland (EU) Tariff"
 

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -68,7 +68,7 @@ describe ServiceHelper, type: :helper do
       let(:choice) { 'uk-old' }
 
       it 'returns The Online Trade Tariff' do
-        expect(trade_tariff_heading).to eq('The Online Trade Tariff')
+        expect(trade_tariff_heading).to eq('Trade Tariff')
       end
     end
 

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -18,7 +18,7 @@ describe ServiceHelper, type: :helper do
       let(:choice) { nil }
 
       it 'returns the title for the current service choice' do
-        expect(helper.default_title).to eq('Trade Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK - GOV.UK')
+        expect(helper.default_title).to eq('The Online Trade Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK - GOV.UK')
       end
     end
   end
@@ -38,7 +38,7 @@ describe ServiceHelper, type: :helper do
       let(:choice) { nil }
 
       it 'returns the correct title for the current goods nomenclature' do
-        expect(helper.goods_nomenclature_title(goods_nomenclature)).to eq('Live horses, asses, mules and hinnies - Trade Tariff - GOV.UK')
+        expect(helper.goods_nomenclature_title(goods_nomenclature)).to eq('Live horses, asses, mules and hinnies - The Online Trade Tariff - GOV.UK')
       end
     end
   end
@@ -58,7 +58,7 @@ describe ServiceHelper, type: :helper do
       let(:choice) { nil }
 
       it 'returns the correct title for the current goods nomenclature' do
-        expect(helper.commodity_title(commodity)).to eq('Commodity code 0101300000 - Pure-bred breeding animals - Trade Tariff - GOV.UK')
+        expect(helper.commodity_title(commodity)).to eq('Commodity code 0101300000: Pure-bred breeding animals - The Online Trade Tariff - GOV.UK')
       end
     end
   end
@@ -68,7 +68,7 @@ describe ServiceHelper, type: :helper do
       let(:choice) { 'uk-old' }
 
       it 'returns The Online Trade Tariff' do
-        expect(trade_tariff_heading).to eq('Trade Tariff')
+        expect(trade_tariff_heading).to eq('The Online Trade Tariff')
       end
     end
 
@@ -119,7 +119,7 @@ describe ServiceHelper, type: :helper do
       let(:choice) { 'xi' }
 
       it 'returns the link to the current UK service' do
-        expect(switch_service_link).to eq(link_to('Trade Tariff', '/sections/1'))
+        expect(switch_service_link).to eq(link_to('The Online Trade Tariff', '/sections/1'))
       end
     end
   end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -5,7 +5,65 @@ describe ServiceHelper, type: :helper do
     allow(TradeTariffFrontend::ServiceChooser).to receive(:service_choice).and_return(choice)
   end
 
-  describe '.trade_tariff_heading' do
+  describe '.default_title' do
+    context 'when the selected service choice is xi' do
+      let(:choice) { 'xi' }
+
+      it 'returns the title for the current service choice' do
+        expect(helper.default_title).to eq('The Northern Ireland (EU) Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK - GOV.UK')
+      end
+    end
+
+    context 'when the selected service choice is nil' do
+      let(:choice) { nil }
+
+      it 'returns the title for the current service choice' do
+        expect(helper.default_title).to eq('Trade Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK - GOV.UK')
+      end
+    end
+  end
+
+  describe '.goods_nomenclature_title' do
+    let(:goods_nomenclature) { double(to_s: 'Live horses, asses, mules and hinnies') }
+
+    context 'when the selected service choice is xi' do
+      let(:choice) { 'xi' }
+
+      it 'returns the correct title for the current goods nomenclature' do
+        expect(helper.goods_nomenclature_title(goods_nomenclature)).to eq('Live horses, asses, mules and hinnies - The Northern Ireland (EU) Tariff - GOV.UK')
+      end
+    end
+
+    context 'when the selected service choice is nil' do
+      let(:choice) { nil }
+
+      it 'returns the correct title for the current goods nomenclature' do
+        expect(helper.goods_nomenclature_title(goods_nomenclature)).to eq('Live horses, asses, mules and hinnies - Trade Tariff - GOV.UK')
+      end
+    end
+  end
+
+  describe '.commodity_title' do
+    let(:commodity) { double(to_s: 'Pure-bred breeding animals', code: '0101300000') }
+
+    context 'when the selected service choice is xi' do
+      let(:choice) { 'xi' }
+
+      it 'returns the correct title for the current goods nomenclature' do
+        expect(helper.commodity_title(commodity)).to eq('Commodity code 0101300000: Pure-bred breeding animals - The Northern Ireland (EU) Tariff - GOV.UK')
+      end
+    end
+
+    context 'when the selected service choice is nil' do
+      let(:choice) { nil }
+
+      it 'returns the correct title for the current goods nomenclature' do
+        expect(helper.commodity_title(commodity)).to eq('Commodity code 0101300000 - Pure-bred breeding animals - Trade Tariff - GOV.UK')
+      end
+    end
+  end
+
+  describe ".trade_tariff_heading" do
     context 'when the selected service choice is uk-old' do
       let(:choice) { 'uk-old' }
 
@@ -61,7 +119,7 @@ describe ServiceHelper, type: :helper do
       let(:choice) { 'xi' }
 
       it 'returns the link to the current UK service' do
-        expect(switch_service_link).to eq(link_to('The Online Trade Tariff', '/sections/1'))
+        expect(switch_service_link).to eq(link_to('Trade Tariff', '/sections/1'))
       end
     end
   end


### PR DESCRIPTION
Jira link: https://transformuk.atlassian.net/browse/HOTT-170

The title (along with the heading) changes between each of the service
backends we're currently routing too and for whether we're looking at
headings, sections, chapters or commodities.

1. Adds title values for when we're using the XI version of the service
2. Adds title values for when we're using the UK version of the service
3. Do this in a way that is easy to remove/update (using I18n)