### PR TITLE
Fixes duplicate GOV.UK

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,7 +11,7 @@ en:
       uk-old: "Commodity code %{commodity_code}: %{commodity_description} - %{service_name} - GOV.UK"
       uk: "Commodity code %{commodity_code}: %{commodity_description} - %{service_name} - GOV.UK"
       xi: "Commodity code %{commodity_code}: %{commodity_description} - %{service_name} - GOV.UK"
-    service_description: "Look up commodity codes, import duty, VAT and controls - GOV.UK"
+    service_description: "Look up commodity codes, import duty, VAT and controls"
     service_name:
       uk-old: "The Online Trade Tariff"
       uk: "The Online Trade Tariff"

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -10,7 +10,7 @@ describe ServiceHelper, type: :helper do
       let(:choice) { 'xi' }
 
       it 'returns the title for the current service choice' do
-        expect(helper.default_title).to eq('The Northern Ireland (EU) Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK - GOV.UK')
+        expect(helper.default_title).to eq('The Northern Ireland (EU) Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK')
       end
     end
 
@@ -18,7 +18,7 @@ describe ServiceHelper, type: :helper do
       let(:choice) { nil }
 
       it 'returns the title for the current service choice' do
-        expect(helper.default_title).to eq('The Online Trade Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK - GOV.UK')
+        expect(helper.default_title).to eq('The Online Trade Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK')
       end
     end
   end


### PR DESCRIPTION
In the default page title the suffix GOV.UK is duplicated due to copy/paste error.

This PR fixes this issue