### PR TITLE
HOTT-192 Refactor links to T&Cs + Cookies

### DIFF
--- a/app/views/layouts/_base.html.erb
+++ b/app/views/layouts/_base.html.erb
@@ -94,14 +94,10 @@
           </a>
         </li>
         <li class="govuk-footer__inline-list-item">
-          <a class="govuk-footer__link" href="/cookies">
-            Cookies
-          </a>
+          <%= link_to 'Cookies', cookies_path, class: 'govuk-footer__link' %>
         </li>
         <li class="govuk-footer__inline-list-item">
-          <a class="govuk-footer__link" href="/terms">
-            Terms and conditions
-          </a>
+          <%= link_to 'Terms and conditions', terms_path, class: 'govuk-footer__link' %>
         </li>
       </ul>
 


### PR DESCRIPTION
# Context
Use the rails url helpers to link to T&Cs + Cookies,
so that when toggling between services, the correct url
is generated for each page.