### PR TITLE
Make sure we can route to the uk backend after frontend app refreshes

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -44,8 +44,7 @@ export PRIVATE_APP_UK=`CF_APP=$CF_APP ruby -e 'puts ENV["CF_APP"].gsub("frontend
 
 cf add-network-policy $CF_APP --destination-app $PRIVATE_APP    --protocol tcp --port 8080
 cf add-network-policy $CF_APP --destination-app $PRIVATE_APP_XI --protocol tcp --port 8080
-# TODO: Roll out UK service in all environments
-# cf add-network-policy $CF_APP --destination-app $PRIVATE_APP_UK --protocol tcp --port 8080
+cf add-network-policy $CF_APP --destination-app $PRIVATE_APP_UK --protocol tcp --port 8080
 
 # Attach autoscaling policy
 cf attach-autoscaling-policy $CF_APP config/autoscaling/"$CF_SPACE"-policy.json


### PR DESCRIPTION
**What**

Uncomment uk backend network policy in deploy script

**Why**

This is needed to make sure that when we refresh the frontend app in the blue-green-deploy process the network policies get recreated and the uk is still routable.