### PR TITLE
Disallow indexing xi and uk routes

### DIFF
--- a/app/views/pages/robots.text.erb
+++ b/app/views/pages/robots.text.erb
@@ -2,7 +2,11 @@
   User-Agent: *
   Allow: /
   Disallow: /*changes$
+  Disallow: /xi*$
+  Disallow: /uk*$
 <% else %>
   User-Agent: *
   Disallow: /
+  Disallow: /xi*$
+  Disallow: /uk*$
 <% end %>


### PR DESCRIPTION
**What**

Disallow indexing of pages for the new services

**Why**

We're going live with these services at a later date and don't want them indexed