### PR TITLE
Add SENTRY release tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,16 @@ jobs:
           cf install-plugin blue-green-deploy -r CF-Community -f
           cf install-plugin app-autoscaler-plugin -r CF-Community -f
           ./bin/deploy
+  sentry_release:
+    runs-on: ubuntu-latest
+    needs: [deploy_dev]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: tariff-frontend
+        with:
+          environment: development

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -41,3 +41,16 @@ jobs:
           cf install-plugin blue-green-deploy -r CF-Community -f
           cf install-plugin app-autoscaler-plugin -r CF-Community -f
           ./bin/deploy
+  sentry_release:
+    runs-on: ubuntu-latest
+    needs: [deploy_production]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: tariff-frontend
+        with:
+          environment: production

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -42,3 +42,16 @@ jobs:
           cf install-plugin blue-green-deploy -r CF-Community -f
           cf install-plugin app-autoscaler-plugin -r CF-Community -f
           ./bin/deploy
+  sentry_release:
+    runs-on: ubuntu-latest
+    needs: [deploy_staging]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: tariff-frontend
+        with:
+          environment: staging


### PR DESCRIPTION
**What:**
Adds release tracking to Sentry.

**Why:**
So that we know what commits introduced a particular issue.