### PR TITLE
Remove the BREXIT_DATE related logic

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,6 @@ class ApplicationController < ActionController::Base
   before_action :sample_requests_for_scout
   before_action :set_last_updated
   before_action :set_cache
-  before_action :preprocess_raw_params
   before_action :search_query
   before_action :maintenance_mode_if_active
   before_action :bots_no_index_if_historical
@@ -91,24 +90,6 @@ class ApplicationController < ActionController::Base
   end
 
   protected
-
-  def preprocess_raw_params
-    if TradeTariffFrontend.block_searching_past_brexit? && params[:year] && params[:month] && params[:day]
-      now = Date.current
-      search_date = begin
-        Date.new(*[params[:year], params[:month], params[:day]].map(&:to_i))
-      rescue ArgumentError
-        now
-      end
-      brexit_date = Date.parse(ENV['BREXIT_DATE'] || '2021-01-01')
-      if (search_date >= brexit_date) && (now < brexit_date)
-        params[:year] = now.year
-        params[:month] = now.month
-        params[:day] = now.day
-        flash[:alert] = "Sorry we are currently unable to display data past #{brexit_date.strftime("#{brexit_date.day.ordinalize} of %B %Y")}"
-      end
-    end
-  end
 
   def maintenance_mode_if_active
     if ENV["MAINTENANCE"].present? && action_name != "maintenance"

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -71,12 +71,6 @@ module TradeTariffFrontend
     ENV.fetch('HIDE_REGULATIONS') != 'true'
   end
 
-  def block_searching_past_brexit?
-    return true unless ENV['ALLOW_SEARCH']
-
-    ENV.fetch('ALLOW_SEARCH') != 'true'
-  end
-
   def download_pdf_enabled?
     ENV.fetch('DOWNLOAD_PDF_ENABLED', 'false') == 'true'
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,68 +1,32 @@
 require 'spec_helper'
 
 describe ApplicationController, type: :controller do
-  describe "behaviour for all subclasses" do
+  describe 'behaviour for all subclasses' do
     controller do
       def index
-        render plain: "Jabberwocky"
+        render plain: 'Jabberwocky'
       end
     end
 
-    describe "caching" do
+    describe 'caching' do
       before do
         get :index
       end
 
-      it "should have a max-age of 2 hours" do
-        expect(response.headers["Cache-Control"]).to include "max-age=7200"
+      it 'has a max-age of 2 hours' do
+        expect(response.headers['Cache-Control']).to include 'max-age=7200'
       end
 
-      it "should have a public directive" do
-        expect(response.headers["Cache-Control"]).to include "public"
+      it 'has a public directive' do
+        expect(response.headers['Cache-Control']).to include 'public'
       end
 
-      it "should have a stale-if-error of 1 day" do
-        expect(response.headers["Cache-Control"]).to include "stale-if-error=86400"
+      it 'has a stale-if-error of 1 day' do
+        expect(response.headers['Cache-Control']).to include 'stale-if-error=86400'
       end
 
-      it "should have a stale-while-revalidate of 1 day" do
-        expect(response.headers["Cache-Control"]).to include "stale-while-revalidate=86400"
-      end
-    end
-  end
-
-  describe '#preprocess_raw_params' do
-    before do
-      ENV['BREXIT_DATE'] = (Date.today + 5.days).to_s
-      ENV['ALLOW_SEARCH'] = nil
-      allow(TradeTariffFrontend).to receive(:block_searching_past_brexit?) { true }
-    end
-
-    after do
-      ENV['BREXIT_DATE'] = nil
-      ENV['ALLOW_SEARCH'] = 'true'
-    end
-
-    context 'when search date is not valid' do
-      before do
-        allow(controller).to receive(:params).and_return({year: '2019', month: '13', day: '54'})
-      end
-
-      it "does not add a flash message" do
-        controller.send(:preprocess_raw_params)
-        expect(controller.flash[:alert]).to_not match(/Sorry/)
-      end
-    end
-
-    context 'when search date is valid' do
-      before do
-        date  = Date.today + 8.days
-        allow(controller).to receive(:params).and_return({year: date.year, month: date.month, day: date.day})
-      end
-
-      it "adds a flash message" do
-        controller.send(:preprocess_raw_params)
-        expect(controller.flash[:alert]).to match(/Sorry/)
+      it 'has a stale-while-revalidate of 1 day' do
+        expect(response.headers['Cache-Control']).to include 'stale-while-revalidate=86400'
       end
     end
   end


### PR DESCRIPTION
# Content
We do not need to block the search in future because
of the BREXIT DATE deadline.

# Ticket
https://transformuk.atlassian.net/browse/HOTT-178