### PR TITLE
Removes currency from search, pdf and application controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
     return super unless search_invoked?
 
     if search_query.date.today? || search_query.date == TradeTariffFrontend.simulation_date
-      return { country: search_query.country, currency: search_query.currency }.merge(super)
+      return { country: search_query.country }.merge(super)
     end
 
     {
@@ -37,7 +37,6 @@ class ApplicationController < ActionController::Base
       month: search_query.date.month,
       day: search_query.date.day,
       country: search_query.country,
-      currency: search_query.currency
     }.merge(super)
   end
 
@@ -80,7 +79,7 @@ class ApplicationController < ActionController::Base
   end
 
   def query_params
-    { as_of: search_query.date, currency: search_query.currency }
+    { as_of: search_query.date }
   end
 
   def set_cache

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,7 +68,7 @@ module ApplicationHelper
       TariffPdf.chapters.map(&:url)
     end
 
-    currency = @search.attributes['currency'] || TradeTariffFrontend.currency_default
+    currency = TradeTariffFrontend::ServiceChooser.currency
 
     pdf_urls.find do |url|
       url =~ /chapters\/#{currency.downcase}\/#{section_position.to_s.rjust(2, '0')}-#{chapter_code}\.pdf/
@@ -82,7 +82,7 @@ module ApplicationHelper
       TariffPdf.latest.map(&:url)
     end
 
-    currency = @search.attributes['currency'] || TradeTariffFrontend.currency_default
+    currency = TradeTariffFrontend::ServiceChooser.currency
 
     pdf_urls.find do |url|
       url =~ /#{currency.downcase}\//

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,8 +68,6 @@ module ApplicationHelper
       TariffPdf.chapters.map(&:url)
     end
 
-    currency = TradeTariffFrontend::ServiceChooser.currency
-
     pdf_urls.find do |url|
       url =~ /chapters\/#{currency.downcase}\/#{section_position.to_s.rjust(2, '0')}-#{chapter_code}\.pdf/
     end
@@ -81,8 +79,6 @@ module ApplicationHelper
 
       TariffPdf.latest.map(&:url)
     end
-
-    currency = TradeTariffFrontend::ServiceChooser.currency
 
     pdf_urls.find do |url|
       url =~ /#{currency.downcase}\//
@@ -102,6 +98,10 @@ module ApplicationHelper
   end
 
   private
+
+  def currency
+    TradeTariffFrontend::ServiceChooser.currency
+  end
 
   def search_date_in_future_month?
     @search&.date.date >= Date.today.at_beginning_of_month.next_month

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -75,9 +75,11 @@ class Search
   end
 
   def query_attributes
-    { 'day'  => date.day,
+    {
+      'day'  => date.day,
       'year' => date.year,
-      'month' => date.month }.merge(attributes.slice(:country))
+      'month' => date.month
+    }.merge(attributes.slice(:country))
   end
 
   def to_s

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -13,7 +13,6 @@ class Search
   delegate :today?, to: :date
 
   def initialize(attributes = {})
-    attributes['currency'].gsub!(/[^a-zA-Z]/, '') if attributes['currency']
     attributes['country'].gsub!(/[^a-zA-Z]/, '') if attributes['country']
     super
   end
@@ -21,7 +20,7 @@ class Search
   def perform
     retries = 0
     begin
-      response = self.class.post('/search', q: q, as_of: date.to_s(:db), currency: currency)
+      response = self.class.post('/search', q: q, as_of: date.to_s(:db))
 
       raise ApiEntity::Error if response.status == 500
 
@@ -59,19 +58,6 @@ class Search
               end
   end
 
-  def currency_name
-    case currency
-    when 'GBP'
-      'Pound sterling'
-    else
-      'Euro'
-    end
-  end
-
-  def currency
-    attributes['currency'] || TradeTariffFrontend.currency_default
-  end
-
   def filtered_by_date?
     date.date != TariffUpdate.latest_applied_import_date
   end
@@ -91,7 +77,7 @@ class Search
   def query_attributes
     { 'day'  => date.day,
       'year' => date.year,
-      'month' => date.month }.merge(attributes.slice(:country, :currency))
+      'month' => date.month }.merge(attributes.slice(:country))
   end
 
   def to_s

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -58,6 +58,15 @@ class Search
               end
   end
 
+  def currency_name
+    case currency
+    when 'GBP'
+      'Pound sterling'
+    else
+      'Euro'
+    end
+  end
+
   def filtered_by_date?
     date.date != TariffUpdate.latest_applied_import_date
   end
@@ -76,9 +85,9 @@ class Search
 
   def query_attributes
     {
-      'day'  => date.day,
+      'day' => date.day,
       'year' => date.year,
-      'month' => date.month
+      'month' => date.month,
     }.merge(attributes.slice(:country))
   end
 

--- a/app/webpacker/src/javascripts/commodities.js.erb
+++ b/app/webpacker/src/javascripts/commodities.js.erb
@@ -452,9 +452,14 @@ import debounce from "./debounce";
           */
           initialize: function () {
             var toggledDataControls = ['js-date-picker'],
+                toggleCurrencyControls = ['js-currency-picker'],
                 namespace = this;
 
             $(toggledDataControls).each(function(idx, element){
+              namespace.toggledControl.initialize(element);
+            });
+
+            $(toggleCurrencyControls).each(function(idx, element){
               namespace.toggledControl.initialize(element);
             });
 

--- a/app/webpacker/src/javascripts/commodities.js.erb
+++ b/app/webpacker/src/javascripts/commodities.js.erb
@@ -452,14 +452,9 @@ import debounce from "./debounce";
           */
           initialize: function () {
             var toggledDataControls = ['js-date-picker'],
-                toggleCurrencyControls = ['js-currency-picker'],
                 namespace = this;
 
             $(toggledDataControls).each(function(idx, element){
-              namespace.toggledControl.initialize(element);
-            });
-
-            $(toggleCurrencyControls).each(function(idx, element){
               namespace.toggledControl.initialize(element);
             });
 

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -49,10 +49,6 @@ module TradeTariffFrontend
     ENV["CURRENCY_PICKER"].to_i == 1
   end
 
-  def currency_default_gbp?
-    ENV.fetch('CURRENCY_GBP', 'false').to_s.downcase == 'true'
-  end
-
   def currency_default
     currency_default_gbp? ? "GBP" : "EUR"
   end
@@ -80,9 +76,17 @@ module TradeTariffFrontend
   end
 
   module ServiceChooser
+    SERVICE_CURRENCIES = {
+      'uk' => 'GBP',
+      'xi' => 'EUR'
+    }.freeze
     SERVICE_DEFAULT = 'uk-old'.freeze
 
     module_function
+
+    def currency
+      SERVICE_CURRENCIES.fetch(service_choice, 'GBP')
+    end
 
     def enabled?
       ENV.fetch('SERVICE_CHOOSING_ENABLED', 'false') == 'true'
@@ -117,8 +121,15 @@ module TradeTariffFrontend
     def cache_prefix
       service_choice || SERVICE_DEFAULT
     end
+
+    def uk?
+      service_choice == 'uk'
+    end
+
+    def xi?
+      service_choice == 'xi'
+    end
   end
-  
 
   # CDN/CDS locking and authentication
   module Locking

--- a/spec/controllers/commodities_controller_spec.rb
+++ b/spec/controllers/commodities_controller_spec.rb
@@ -48,10 +48,7 @@ describe CommoditiesController, type: :controller do
 
       it 'redirects to actual version of the commodity page' do
         expect(response.status).to eq 302
-        expect(response.location).to eq commodity_url(
-                                            id: commodity_id.first(10),
-                                            currency: 'EUR'
-                                        )
+        expect(response.location).to eq commodity_url(id: commodity_id.first(10))
       end
     end
   end

--- a/spec/trade_tariff_frontend/service_chooser_spec.rb
+++ b/spec/trade_tariff_frontend/service_chooser_spec.rb
@@ -75,4 +75,34 @@ describe TradeTariffFrontend::ServiceChooser do
       end
     end
   end
+
+  describe '.currency' do
+    before do
+      allow(described_class).to receive(:service_choice).and_return(choice)
+    end
+
+    context 'when the service is xi' do
+      let(:choice) { 'xi' }
+
+      it 'returns the correct currency' do
+        expect(described_class.currency).to eq('EUR')
+      end
+    end
+
+    context 'when the service is uk' do
+      let(:choice) { 'uk' }
+
+      it 'returns the correct currency' do
+        expect(described_class.currency).to eq('GBP')
+      end
+    end
+
+    context 'when the service is not set' do
+      let(:choice) { nil }
+
+      it 'returns the correct currency' do
+        expect(described_class.currency).to eq('GBP')
+      end
+    end
+  end
 end

--- a/spec/vcr/chapters_changes_index.yml
+++ b/spec/vcr/chapters_changes_index.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/chapters/01?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/chapters/01?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:39 GMT
 - request:
     method: get
-    uri: http://localhost:3018/chapters/01/changes?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/chapters/01/changes?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/chapters_changes_index_0100000000_1970-01-01.yml
+++ b/spec/vcr/chapters_changes_index_0100000000_1970-01-01.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/chapters/01?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/chapters/01?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:40 GMT
 - request:
     method: get
-    uri: http://localhost:3018/chapters/01?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/chapters/01?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:40 GMT
 - request:
     method: get
-    uri: http://localhost:3018/chapters/01?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/chapters/01?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:40 GMT
 - request:
     method: get
-    uri: http://localhost:3018/chapters/01?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/chapters/01?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -158,7 +158,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:40 GMT
 - request:
     method: get
-    uri: http://localhost:3018/chapters/01?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/chapters/01?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -197,7 +197,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:40 GMT
 - request:
     method: get
-    uri: http://localhost:3018/chapters/01?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/chapters/01?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/chapters_changes_index_0100000000_1972-01-01.yml
+++ b/spec/vcr/chapters_changes_index_0100000000_1972-01-01.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/chapters/01?as_of=1972-01-01&currency=EUR
+    uri: http://localhost:3018/chapters/01?as_of=1972-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:40 GMT
 - request:
     method: get
-    uri: http://localhost:3018/chapters/01/changes?as_of=1972-01-01&currency=EUR
+    uri: http://localhost:3018/chapters/01/changes?as_of=1972-01-01
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/chapters_show.yml
+++ b/spec/vcr/chapters_show.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/chapters/01?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/chapters/01?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_changes_index.yml
+++ b/spec/vcr/commodities_changes_index.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:33 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000/changes?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000/changes?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_changes_index_4302130000_1998-01-01.yml
+++ b/spec/vcr/commodities_changes_index_4302130000_1998-01-01.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/4302130000?as_of=1998-01-01&currency=EUR
+    uri: http://localhost:3018/commodities/4302130000?as_of=1998-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:34 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/4302130000/changes?as_of=1998-01-01&currency=EUR
+    uri: http://localhost:3018/commodities/4302130000/changes?as_of=1998-01-01
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_changes_index_4302130000_2013-11-11.yml
+++ b/spec/vcr/commodities_changes_index_4302130000_2013-11-11.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11&currency=EUR
+    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11
     body:
       encoding: US-ASCII
       string: ''
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:33 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11&currency=EUR
+    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:33 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11&currency=EUR
+    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:33 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11&currency=EUR
+    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11
     body:
       encoding: US-ASCII
       string: ''
@@ -158,7 +158,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:33 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11&currency=EUR
+    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11
     body:
       encoding: US-ASCII
       string: ''
@@ -197,7 +197,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:33 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11&currency=EUR
+    uri: http://localhost:3018/commodities/4302130000?as_of=2013-11-11
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_show.yml
+++ b/spec/vcr/commodities_show.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101300000?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/0101300000?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_show_010121000_2000-01-01.yml
+++ b/spec/vcr/commodities_show_010121000_2000-01-01.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Mon, 11 Nov 2013 12:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Mon, 11 Nov 2013 12:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
   recorded_at: Mon, 11 Nov 2013 12:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -158,7 +158,7 @@ http_interactions:
   recorded_at: Mon, 11 Nov 2013 12:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -197,7 +197,7 @@ http_interactions:
   recorded_at: Mon, 11 Nov 2013 12:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2000-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -239,7 +239,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=0101210000&as_of=2013-11-11&currency=EUR
+      string: q=0101210000&as_of=2013-11-11
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr/commodities_show_0101300000.yml
+++ b/spec/vcr/commodities_show_0101300000.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101300000?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/0101300000?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_show_0101999999.yml
+++ b/spec/vcr/commodities_show_0101999999.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -158,7 +158,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -197,7 +197,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/0101999999?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -239,7 +239,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=0101999999&as_of=2018-11-15&currency=EUR
+      string: q=0101999999&as_of=2018-11-15
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr/commodities_show_0201100021_legal_base_hidden.yml
+++ b/spec/vcr/commodities_show_0201100021_legal_base_hidden.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0201100021?as_of=2019-02-21&currency=EUR
+    uri: http://localhost:3018/commodities/0201100021?as_of=2019-02-21
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_show_0201100021_legal_base_visible.yml
+++ b/spec/vcr/commodities_show_0201100021_legal_base_visible.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0201100021?as_of=2019-02-21&currency=EUR
+    uri: http://localhost:3018/commodities/0201100021?as_of=2019-02-21
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_show_0201100021_legal_base_visible_no_env.yml
+++ b/spec/vcr/commodities_show_0201100021_legal_base_visible_no_env.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0201100021?as_of=2019-02-21&currency=EUR
+    uri: http://localhost:3018/commodities/0201100021?as_of=2019-02-21
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_show_0201300020.yml
+++ b/spec/vcr/commodities_show_0201300020.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0201300020?as_of=2014-05-31&currency=EUR
+    uri: http://localhost:3018/commodities/0201300020?as_of=2014-05-31
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_show_1701910000_2006-02-01.yml
+++ b/spec/vcr/commodities_show_1701910000_2006-02-01.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/1701910000?as_of=2006-02-01&currency=EUR
+    uri: http://localhost:3018/commodities/1701910000?as_of=2006-02-01
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_show_2208909110.yml
+++ b/spec/vcr/commodities_show_2208909110.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/2208909110?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/2208909110?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/commodities_show_8714930019.yml
+++ b/spec/vcr/commodities_show_8714930019.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/8714930019?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/8714930019?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/country_filtering.yml
+++ b/spec/vcr/country_filtering.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-04&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-04
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=&as_of=2019-03-04&currency=EUR
+      string: q=&as_of=2019-03-04
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -85,7 +85,7 @@ http_interactions:
   recorded_at: Mon, 04 Mar 2019 18:30:13 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-04&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-04
     body:
       encoding: US-ASCII
       string: ''
@@ -130,7 +130,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=&as_of=2019-03-04&currency=EUR
+      string: q=&as_of=2019-03-04
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -168,7 +168,7 @@ http_interactions:
   recorded_at: Mon, 04 Mar 2019 18:30:17 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-04&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-04
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
   recorded_at: Mon, 04 Mar 2019 18:30:19 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-05&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-05
     body:
       encoding: US-ASCII
       string: ''
@@ -252,7 +252,7 @@ http_interactions:
   recorded_at: Tue, 05 Mar 2019 10:21:44 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-05&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-05
     body:
       encoding: US-ASCII
       string: ''
@@ -294,7 +294,7 @@ http_interactions:
   recorded_at: Tue, 05 Mar 2019 10:21:50 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-05&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2019-03-05
     body:
       encoding: US-ASCII
       string: ''
@@ -378,7 +378,7 @@ http_interactions:
   recorded_at: Tue, 05 Mar 2019 10:53:04 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=2019-03-05&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=2019-03-05
     body:
       encoding: US-ASCII
       string: ''
@@ -464,7 +464,7 @@ http_interactions:
   recorded_at: Thu, 16 May 2019 22:05:58 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=2019-03-05&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=2019-03-05
     body:
       encoding: US-ASCII
       string: ''
@@ -550,7 +550,7 @@ http_interactions:
   recorded_at: Thu, 16 May 2019 22:06:04 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=2019-03-05&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=2019-03-05
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/date_currency.yml
+++ b/spec/vcr/date_currency.yml
@@ -80,7 +80,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=&as_of=2018-12-01&currency=EUR
+      string: q=&as_of=2018-12-01
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr/headings_8501.yml
+++ b/spec/vcr/headings_8501.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/headings/8501?as_of=2014-05-31&currency=EUR
+    uri: http://localhost:3018/headings/8501?as_of=2014-05-31
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/headings_changes_index.yml
+++ b/spec/vcr/headings_changes_index.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:32 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101/changes?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/headings/0101/changes?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/headings_changes_index_0101000000_1970-01-01.yml
+++ b/spec/vcr/headings_changes_index_0101000000_1970-01-01.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -158,7 +158,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -197,7 +197,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=1970-01-01&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=1970-01-01
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/headings_changes_index_0101000000_1972-01-01.yml
+++ b/spec/vcr/headings_changes_index_0101000000_1972-01-01.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=1972-01-01&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=1972-01-01
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 14:59:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101/changes?as_of=1972-01-01&currency=EUR
+    uri: http://localhost:3018/headings/0101/changes?as_of=1972-01-01
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/headings_show.yml
+++ b/spec/vcr/headings_show.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/headings_show_0101.yml
+++ b/spec/vcr/headings_show_0101.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/headings/0101?as_of=2019-05-16&currency=EUR
+    uri: http://localhost:3018/headings/0101?as_of=2019-05-16
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/headings_show_0110.yml
+++ b/spec/vcr/headings_show_0110.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/headings/0110?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/headings/0110?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 09:59:22 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0110?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/headings/0110?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 09:59:22 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0110?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/headings/0110?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 09:59:22 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0110?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/headings/0110?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -158,7 +158,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 09:59:22 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0110?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/headings/0110?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -197,7 +197,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 09:59:22 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0110?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/headings/0110?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -239,7 +239,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=0110&as_of=2018-11-15&currency=EUR
+      string: q=0110&as_of=2018-11-15
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr/headings_show_0201.yml
+++ b/spec/vcr/headings_show_0201.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0201100021?as_of=2018-05-31&currency=EUR
+    uri: http://localhost:3018/commodities/0201100021?as_of=2018-05-31
     body:
       encoding: US-ASCII
       string: ''
@@ -50,7 +50,7 @@ http_interactions:
   recorded_at: Fri, 18 Dec 2020 22:27:04 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/0201?as_of=2018-05-31&currency=EUR
+    uri: http://localhost:3018/headings/0201?as_of=2018-05-31
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/headings_show_1701.yml
+++ b/spec/vcr/headings_show_1701.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/headings/1701?as_of=2006-02-01&currency=EUR
+    uri: http://localhost:3018/headings/1701?as_of=2006-02-01
     body:
       encoding: US-ASCII
       string: ''
@@ -365,7 +365,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: as_of=2020-12-18&currency=EUR&q=1701910000
+      string: as_of=2020-12-18&q=1701910000
     headers:
       Accept:
       - application/vnd.uktt.v2
@@ -411,7 +411,7 @@ http_interactions:
   recorded_at: Fri, 18 Dec 2020 19:34:43 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/1701910000?as_of=2020-12-18&currency=EUR
+    uri: http://localhost:3018/commodities/1701910000?as_of=2020-12-18
     body:
       encoding: US-ASCII
       string: ''
@@ -459,7 +459,7 @@ http_interactions:
   recorded_at: Fri, 18 Dec 2020 19:34:43 GMT
 - request:
     method: get
-    uri: http://localhost:3018/headings/1701?as_of=2020-12-18&currency=EUR
+    uri: http://localhost:3018/headings/1701?as_of=2020-12-18
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/headings_show_2208.yml
+++ b/spec/vcr/headings_show_2208.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/headings/2208?as_of=2019-05-16&currency=EUR
+    uri: http://localhost:3018/headings/2208?as_of=2019-05-16
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/headings_show_8714.yml
+++ b/spec/vcr/headings_show_8714.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/headings/8714?as_of=2019-05-16&currency=EUR
+    uri: http://localhost:3018/headings/8714?as_of=2019-05-16
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/headings_show_declarable.yml
+++ b/spec/vcr/headings_show_declarable.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/headings/0501?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/headings/0501?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/search_blank_match.yml
+++ b/spec/vcr/search_blank_match.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: as_of=2019-10-03&currency=EUR&q
+      string: as_of=2019-10-03&q
     headers:
       Accept:
       - application/vnd.uktt.v2

--- a/spec/vcr/search_duplicate_results.yml
+++ b/spec/vcr/search_duplicate_results.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=synonym%201&as_of=2018-11-15&currency=EUR
+      string: q=synonym%201&as_of=2018-11-15
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -43,7 +43,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 16:06:33 GMT
 - request:
     method: get
-    uri: http://localhost:3018/sections/1?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/sections/1?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -96,7 +96,7 @@ http_interactions:
         to the young of that genus or species.\r\n* 2\\. Except where the context
         otherwise requires, throughout the nomenclature any reference to ''dried''
         products also covers products which have been dehydrated, evaporated or freeze-dried.\r\n\r\ntest
-        ","_response_info":{"links":[{"rel":"self","href":"/trade-tariff/sections/1?as_of=2018-11-15&currency=EUR"},{"rel":"sections","href":"/trade-tariff/sections"}]}}'
+        ","_response_info":{"links":[{"rel":"self","href":"/trade-tariff/sections/1?as_of=2018-11-15"},{"rel":"sections","href":"/trade-tariff/sections"}]}}'
     http_version: 
   recorded_at: Thu, 15 Nov 2018 16:06:34 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr/search_fuzzy_match.yml
+++ b/spec/vcr/search_fuzzy_match.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=horses&as_of=2018-11-15&currency=EUR
+      string: q=horses&as_of=2018-11-15
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr/search_gibberish.yml
+++ b/spec/vcr/search_gibberish.yml
@@ -47,7 +47,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=dsauidoasuiodsa&as_of=2019-02-01&currency=EUR
+      string: q=dsauidoasuiodsa&as_of=2019-02-01
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr/search_gold.yml
+++ b/spec/vcr/search_gold.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=gold&as_of=2019-02-01&currency=EUR
+      string: q=gold&as_of=2019-02-01
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -122,7 +122,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=dsauidoasuiodsa&as_of=2019-02-01&currency=EUR
+      string: q=dsauidoasuiodsa&as_of=2019-02-01
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3

--- a/spec/vcr/search_search_exact.yml
+++ b/spec/vcr/search_search_exact.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=0101210000&as_of=2018-11-15&currency=EUR
+      string: q=0101210000&as_of=2018-11-15
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -43,7 +43,7 @@ http_interactions:
   recorded_at: Thu, 15 Nov 2018 15:11:31 GMT
 - request:
     method: get
-    uri: http://localhost:3018/commodities/0101210000?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/commodities/0101210000?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr/search_search_fuzzy.yml
+++ b/spec/vcr/search_search_fuzzy.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: q=horses&as_of=2018-11-15&currency=EUR
+      string: q=horses&as_of=2018-11-15
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -155,7 +155,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: as_of=2019-04-05&currency=EUR&q=car+parts
+      string: as_of=2019-04-05&q=car+parts
     headers:
       Accept:
       - application/vnd.uktt.v2
@@ -199,7 +199,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: as_of=2019-04-05&currency=EUR&q=account+books
+      string: as_of=2019-04-05&q=account+books
     headers:
       Accept:
       - application/vnd.uktt.v2
@@ -521,7 +521,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: as_of=2019-04-05&currency=EUR&q=minerals
+      string: as_of=2019-04-05&q=minerals
     headers:
       Accept:
       - application/vnd.uktt.v2
@@ -565,7 +565,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: as_of=2019-04-05&currency=EUR&q=designed+velocycles
+      string: as_of=2019-04-05&q=designed+velocycles
     headers:
       Accept:
       - application/vnd.uktt.v2
@@ -608,7 +608,7 @@ http_interactions:
     uri: http://localhost:3018/search
     body:
       encoding: UTF-8
-      string: as_of=2019-04-05&currency=EUR&q=2204
+      string: as_of=2019-04-05&q=2204
     headers:
       Accept:
       - application/vnd.uktt.v2

--- a/spec/vcr/sections_show.yml
+++ b/spec/vcr/sections_show.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3018/sections/1?as_of=2018-11-15&currency=EUR
+    uri: http://localhost:3018/sections/1?as_of=2018-11-15
     body:
       encoding: US-ASCII
       string: ''
@@ -55,7 +55,7 @@ http_interactions:
         to the young of that genus or species.\r\n* 2\\. Except where the context
         otherwise requires, throughout the nomenclature any reference to ''dried''
         products also covers products which have been dehydrated, evaporated or freeze-dried.\r\n\r\ntest
-        ","_response_info":{"links":[{"rel":"self","href":"/trade-tariff/sections/1?as_of=2018-11-15&currency=EUR"},{"rel":"sections","href":"/trade-tariff/sections"}]}}'
+        ","_response_info":{"links":[{"rel":"self","href":"/trade-tariff/sections/1?as_of=2018-11-15"},{"rel":"sections","href":"/trade-tariff/sections"}]}}'
     http_version: 
   recorded_at: Thu, 15 Nov 2018 14:59:11 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
### What

The decision about the returned currency is now decided by the backend service we're using (see https://github.com/TransformCore/trade-tariff-backend/pull/21).

When the service is `uk` we show rates in `GBP`
When the service is `xi` we show rates in `EUR`
When the service is not set we show rates in `GBP`

This PR takes the decision making capacity of the frontend around the currency away. We seem to be making this decision via the query param mechanism which is handed to various apis in the backend including:

1. Around specific measure components returned for goods nomenclatures
2. Around pdf generation
3. Around searching through ES

### Why

This is to simplify/clarify the behaviour of the backend services. UK measures will have their monetary unit in GBP (ignoring end-dated measure components before 2021/01/01)

### AC

- [x] Searching through the frontend doesn't inject the currency anymore
- [x] Using the currency query param doesn't break the service