### PR TITLE
HOTT-266 BUG FIX - Use the correct CSS class on Tools page

### DIFF
--- a/app/views/pages/tools.html.erb
+++ b/app/views/pages/tools.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="column-full-witdh">
+  <div class="govuk-grid-column-full">
     <span class="govuk-caption-xl govuk-!-margin-top-0"><%= trade_tariff_heading %></span>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">Tariff tools</h1>
     <%= service_switch_banner %>


### PR DESCRIPTION
# Context
The correct class to use for a full width column is:
govuk-grid-column-full.

# Ticket
https://transformuk.atlassian.net/browse/HOTT-266