### PR TITLE
Use an env var to choose service default

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -13,3 +13,4 @@ NOTICE_BANNER="NOTICE|This service is currently being updated, some data might b
 HTTPARTY_READ_TIMEOUT=661
 TARIFF_API_VERSION=2
 SERVICE_CHOOSING_ENABLED=true
+SERVICE_DEFAULT=uk-old

--- a/.env.test
+++ b/.env.test
@@ -12,3 +12,4 @@ ALLOW_SEARCH='true'
 NOTICE_BANNER="NOTICE|This service is currently being updated, some data might be missing."
 HTTPARTY_READ_TIMEOUT=661
 TARIFF_API_VERSION=2
+SERVICE_DEFAULT=uk-old

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -58,7 +58,7 @@ private
 
   def service_choice
     TradeTariffFrontend::ServiceChooser.service_choice ||
-      TradeTariffFrontend::ServiceChooser::SERVICE_DEFAULT
+      TradeTariffFrontend::ServiceChooser.service_default
   end
 
   def banner_copy

--- a/lib/routing_filter/service_path_prefix_handler.rb
+++ b/lib/routing_filter/service_path_prefix_handler.rb
@@ -34,7 +34,7 @@ module RoutingFilter
     attr_reader :path, :service_choice
 
     def service_choice_default
-      ::TradeTariffFrontend::ServiceChooser::SERVICE_DEFAULT
+      ::TradeTariffFrontend::ServiceChooser.service_default
     end
   end
 end

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -84,7 +84,7 @@ module TradeTariffFrontend
     module_function
 
     def service_default
-      ENV.fetch('SERVICE_DEFAULT ', 'uk-old')
+      ENV.fetch('SERVICE_DEFAULT', 'uk-old')
     end
 
     def currency

--- a/lib/trade_tariff_frontend.rb
+++ b/lib/trade_tariff_frontend.rb
@@ -80,9 +80,12 @@ module TradeTariffFrontend
       'uk' => 'GBP',
       'xi' => 'EUR'
     }.freeze
-    SERVICE_DEFAULT = 'uk-old'.freeze
 
     module_function
+
+    def service_default
+      ENV.fetch('SERVICE_DEFAULT ', 'uk-old')
+    end
 
     def currency
       SERVICE_CURRENCIES.fetch(service_choice, 'GBP')
@@ -113,13 +116,13 @@ module TradeTariffFrontend
     def api_host
       host = service_choices[service_choice]
 
-      return service_choices[SERVICE_DEFAULT] if host.blank?
+      return service_choices[service_default] if host.blank?
 
       host
     end
 
     def cache_prefix
-      service_choice || SERVICE_DEFAULT
+      service_choice || service_default
     end
 
     def uk?


### PR DESCRIPTION
### What

Making the service default configurable via the environment

### Why

To not need to deploy code changes to achieve a change in the behaviour of the frontend default service

### A/C

- [ ] Default routing on dev still works