### PR TITLE
Show the correct banner on the service

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -62,7 +62,7 @@ private
   end
 
   def banner_copy
-    return t("service_banner.big.#{service_choice}", link: switch_service_link).html_safe if current_path == '/sections'
+    return t("service_banner.big.#{service_choice}", link: switch_service_link).html_safe if request.filtered_path == sections_path
 
     t('service_banner.small', link: switch_service_link).html_safe
   end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -75,7 +75,7 @@ describe SearchController, "GET to #search", type: :controller do
           it { expect(assigns(:search)).to be_a(Search) }
           it { should redirect_to(chapter_path("01", year: year, month: month, day: day)) }
         end
-
+        
         xcontext 'valid pre-EU Exit date params provided' do
           let(:future_date) { Date.new(2020, 12, 31) }
           let(:year)    { future_date.year }

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -125,7 +125,7 @@ describe ServiceHelper, type: :helper do
   end
 
   describe '.service_switch_banner' do
-    let(:request) { double('request', filtered_path: '/tools') }
+    let(:request) { double('request', filtered_path: '/xi/sections/1') }
     let(:choice) { 'xi' }
     let(:service_choosing_enabled) { true }
 
@@ -133,8 +133,8 @@ describe ServiceHelper, type: :helper do
       allow(TradeTariffFrontend::ServiceChooser).to receive(:enabled?).and_return(service_choosing_enabled)
     end
 
-    context 'when on sections page' do
-      let(:request) { double('request', filtered_path: '/sections') }
+    context 'when on xi sections page' do
+      let(:request) { double('request', filtered_path: '/xi/sections') }
 
       it 'returns the full banner that allows users to toggle between the services' do
         expect(service_switch_banner).to include(t("service_banner.big.#{choice}", link: switch_service_link))


### PR DESCRIPTION
# Context
When on the main sections page, with or without query string
params, the full banner should be displayed.

Any other page will display the subtle banner.

# Ticket
https://transformuk.atlassian.net/browse/HOTT-287